### PR TITLE
Code in errors maps at the top level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.30.1 -- 24 Sep 2021
+
+Add `:code` in the error maps at the top level for backward compatibility, you should use the one in `:extensions.
+
 ## 0.30.0 -- 1 Oct 2018
 
 A field resolver that returns a list of values may now wrap the individual

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.walmartlabs/lacinia "0.30.0"
+(defproject com.walmartlabs/lacinia "0.30.1"
   :description "A GraphQL server implementation in Clojure"
   :license {:name "Apache, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}

--- a/src/com/walmartlabs/lacinia/executor.clj
+++ b/src/com/walmartlabs/lacinia/executor.clj
@@ -57,16 +57,17 @@
 
 (defn ^:private structured-error-map
   "Converts an error map and extra data about location, path, etc. into the
-  correct format:  top level keys :message, :path, and :location, and anything else
-  under a :extensions key."
+  correct format:  top level keys :message, :path, :location, :code, and anything else
+  under a :extensions key. :code is at the top for backward compatibility reason."
   [error-map extra-data]
-  (let [{:keys [message]} error-map
+  (let [{:keys [message code]} error-map
         {:keys [locations path]} extra-data
         extensions (merge (dissoc error-map :message)
                           (dissoc extra-data :locations :path))]
     (cond-> {:message message
              :locations locations
              :path path}
+            (integer? code) (assoc :code code)
       (seq extensions) (assoc :extensions extensions))))
 
 (defn ^:private enhance-errors


### PR DESCRIPTION
Copy of the code field in the errors maps at the top level.
Please use the code in errors[0].extensions.code